### PR TITLE
Prettier unknown option warning on checks

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,6 +6,5 @@
   "singleQuote": false,
   "trailingComma": "all",
   "bracketSpacing": true,
-  "jsxBracketSameLine": false,
-  "fluid": false
+  "jsxBracketSameLine": false
 }


### PR DESCRIPTION
Prettier warn us during the check on CI: `[warn] Ignored unknown option { fluid: false }.`

See: https://github.com/Spy-Seth/prettier-plugin-gherkin/pull/22/checks?check_run_id=75399753